### PR TITLE
feat(options): add WriteSyncers option allowing use of multiple writers 

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -142,7 +142,7 @@ func NewCore(options ...Option) (_ zapcore.Core, err error) {
 
 	var core = zapcore.NewCore(
 		zapcore.NewJSONEncoder(conf.encoder),
-		zapcore.AddSync(w),
+		w,
 		conf.enabler,
 	)
 
@@ -338,6 +338,9 @@ func CompressionLevel(value int) Option {
 	})
 }
 
+// Ensure *writer implements zapcore.WriteSyncer.
+var _ zapcore.WriteSyncer = (*writer)(nil)
+
 // Write implements io.Writer.
 func (w *writer) Write(buf []byte) (n int, err error) {
 	var (
@@ -378,6 +381,11 @@ func (w *writer) Write(buf []byte) (n int, err error) {
 	}
 
 	return n, nil
+}
+
+// Sync is a no-op, but required to implement the zapcore.WriteSyncer interface.
+func (w *writer) Sync() error {
+	return nil
 }
 
 // Close implementation of io.WriteCloser.

--- a/gelf.go
+++ b/gelf.go
@@ -140,9 +140,16 @@ func NewCore(options ...Option) (_ zapcore.Core, err error) {
 		return nil, err
 	}
 
+	var ws zapcore.WriteSyncer = w
+
+	if len(conf.writeSyncers) > 0 {
+		writers := append([]zapcore.WriteSyncer{w}, conf.writeSyncers...)
+		ws = zapcore.NewMultiWriteSyncer(writers...)
+	}
+
 	var core = zapcore.NewCore(
 		zapcore.NewJSONEncoder(conf.encoder),
-		w,
+		ws,
 		conf.enabler,
 	)
 
@@ -270,6 +277,14 @@ func EncodeCaller(value zapcore.CallerEncoder) Option {
 func EncodeName(value zapcore.NameEncoder) Option {
 	return optionFunc(func(conf *optionConf) error {
 		conf.encoder.EncodeName = value
+		return nil
+	})
+}
+
+// WriteSyncers sets additional zapcore.WriteSyncers on the core.
+func WriteSyncers(value ...zapcore.WriteSyncer) Option {
+	return optionFunc(func(conf *optionConf) error {
+		conf.writeSyncers = append(conf.writeSyncers, value...)
 		return nil
 	})
 }

--- a/gelf_test.go
+++ b/gelf_test.go
@@ -3,6 +3,7 @@ package gelf_test
 import (
 	"encoding/json"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,15 @@ func TestEncodeCaller(t *testing.T) {
 func TestEncodeName(t *testing.T) {
 	var core, err = gelf.NewCore(
 		gelf.EncodeName(zapcore.FullNameEncoder),
+	)
+
+	assert.Nil(t, err, "Unexpected error")
+	assert.Implements(t, (*zapcore.Core)(nil), core, "Expect zapcore.Core")
+}
+
+func TestWriteSyncers(t *testing.T) {
+	var core, err = gelf.NewCore(
+		gelf.WriteSyncers(os.Stderr),
 	)
 
 	assert.Nil(t, err, "Unexpected error")


### PR DESCRIPTION
Allows adding both `os.Stdout` and `os.Stderr` as a writer target in addition to GELF.

Anything which implements `zapcore.WriteSyncer` can be added.