### PR TITLE
feat(options): add WriteSyncers option allowing use of multiple writers 

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -94,6 +94,9 @@ var (
 	// chunkedMagicBytes chunked message magic bytes.
 	// See http://docs.graylog.org/en/2.4/pages/gelf.html.
 	chunkedMagicBytes = []byte{0x1e, 0x0f}
+
+	// Ensure *writer implements zapcore.WriteSyncer.
+	_ zapcore.WriteSyncer = (*writer)(nil)
 )
 
 // NewCore zap core constructor.
@@ -142,7 +145,7 @@ func NewCore(options ...Option) (_ zapcore.Core, err error) {
 
 	var core = zapcore.NewCore(
 		zapcore.NewJSONEncoder(conf.encoder),
-		zapcore.AddSync(w),
+		w,
 		conf.enabler,
 	)
 
@@ -378,6 +381,11 @@ func (w *writer) Write(buf []byte) (n int, err error) {
 	}
 
 	return n, nil
+}
+
+// Sync is a no-op, but required to implement the zapcore.WriteSyncer interface.
+func (w *writer) Sync() error {
+	return nil
 }
 
 // Close implementation of io.WriteCloser.

--- a/gelf.go
+++ b/gelf.go
@@ -143,9 +143,15 @@ func NewCore(options ...Option) (_ zapcore.Core, err error) {
 		return nil, err
 	}
 
+	var ws zapcore.WriteSyncer = w
+	if len(conf.writeSyncers) > 0 {
+		var writers = append([]zapcore.WriteSyncer{w}, conf.writeSyncers...)
+		ws = zapcore.NewMultiWriteSyncer(writers...)
+	}
+
 	var core = zapcore.NewCore(
 		zapcore.NewJSONEncoder(conf.encoder),
-		w,
+		ws,
 		conf.enabler,
 	)
 
@@ -273,6 +279,14 @@ func EncodeCaller(value zapcore.CallerEncoder) Option {
 func EncodeName(value zapcore.NameEncoder) Option {
 	return optionFunc(func(conf *optionConf) error {
 		conf.encoder.EncodeName = value
+		return nil
+	})
+}
+
+// WriteSyncers sets additional zapcore.WriteSyncers on the core.
+func WriteSyncers(value ...zapcore.WriteSyncer) Option {
+	return optionFunc(func(conf *optionConf) error {
+		conf.writeSyncers = append(conf.writeSyncers, value...)
 		return nil
 	})
 }

--- a/gelf_test.go
+++ b/gelf_test.go
@@ -3,6 +3,7 @@ package gelf_test
 import (
 	"encoding/json"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,15 @@ func TestEncodeCaller(t *testing.T) {
 func TestEncodeName(t *testing.T) {
 	var core, err = gelf.NewCore(
 		gelf.EncodeName(zapcore.FullNameEncoder),
+	)
+
+	assert.Nil(t, err, "Unexpected error")
+	assert.Implements(t, (*zapcore.Core)(nil), core, "Expect zapcore.Core")
+}
+
+func TestWriteSyncers(t *testing.T) {
+	var core, err = gelf.NewCore(
+		gelf.WriteSyncers(os.Stderr),
 	)
 
 	assert.Nil(t, err, "Unexpected error")


### PR DESCRIPTION
Allows adding both `os.Stdout` and `os.Stderr` as a writer target in addition to GELF.

Anything which implements `zapcore.WriteSyncer` can be added.

---

Apologies for the noise. This PR supersedes #4 as it's from a fork where more people than just me are able to maintain it if needed.