### PR TITLE
Add configuration option for zap.NewAtomicLevel() in order to change level dynamically.

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -202,6 +202,14 @@ func TimeKey(value string) Option {
 	})
 }
 
+// DynamicLevel set dynamic logging level.
+func DynamicLevel(level zap.AtomicLevel) Option {
+	return optionFunc(func(conf *optionConf) (err error) {
+		conf.enabler = level
+		return nil
+	})
+}
+
 // NameKey set zapcore.EncoderConfig NameKey property.
 func NameKey(value string) Option {
 	return optionFunc(func(conf *optionConf) error {

--- a/gelf.go
+++ b/gelf.go
@@ -202,8 +202,8 @@ func TimeKey(value string) Option {
 	})
 }
 
-// DynamicLevel set dynamic logging level.
-func DynamicLevel(level zap.AtomicLevel) Option {
+// LevelAtomic set atomic logging level which can be changed dynamically.
+func LevelAtomic(level zap.AtomicLevel) Option {
 	return optionFunc(func(conf *optionConf) (err error) {
 		conf.enabler = level
 		return nil

--- a/gelf_test.go
+++ b/gelf_test.go
@@ -181,12 +181,12 @@ func TestLevelString(t *testing.T) {
 	assert.False(t, core.Enabled(zap.WarnLevel))
 }
 
-func TestDynamicLevel(t *testing.T) {
-	dynamicLevel := zap.NewAtomicLevel()
-	dynamicLevel.SetLevel(zap.ErrorLevel)
+func TestLevelAtomic(t *testing.T) {
+	atomicLevel := zap.NewAtomicLevel()
+	atomicLevel.SetLevel(zap.ErrorLevel)
 
 	var core, err = gelf.NewCore(
-		gelf.DynamicLevel(dynamicLevel),
+		gelf.LevelAtomic(atomicLevel),
 	)
 
 	assert.Nil(t, err, "Unexpected error")
@@ -194,7 +194,7 @@ func TestDynamicLevel(t *testing.T) {
 	assert.True(t, core.Enabled(zap.ErrorLevel))
 	assert.False(t, core.Enabled(zap.WarnLevel))
 
-	dynamicLevel.SetLevel(zap.WarnLevel)
+	atomicLevel.SetLevel(zap.WarnLevel)
 
 	assert.True(t, core.Enabled(zap.ErrorLevel))
 	assert.True(t, core.Enabled(zap.WarnLevel))

--- a/gelf_test.go
+++ b/gelf_test.go
@@ -161,20 +161,43 @@ func TestNewReflectedEncoder(t *testing.T) {
 
 func TestLevel(t *testing.T) {
 	var core, err = gelf.NewCore(
-		gelf.Level(zap.DebugLevel),
+		gelf.Level(zap.ErrorLevel),
 	)
 
 	assert.Nil(t, err, "Unexpected error")
 	assert.Implements(t, (*zapcore.Core)(nil), core, "Expect zapcore.Core")
+	assert.True(t, core.Enabled(zap.ErrorLevel))
+	assert.False(t, core.Enabled(zap.WarnLevel))
 }
 
 func TestLevelString(t *testing.T) {
 	var core, err = gelf.NewCore(
-		gelf.LevelString("debug"),
+		gelf.LevelString("error"),
 	)
 
 	assert.Nil(t, err, "Unexpected error")
 	assert.Implements(t, (*zapcore.Core)(nil), core, "Expect zapcore.Core")
+	assert.True(t, core.Enabled(zap.ErrorLevel))
+	assert.False(t, core.Enabled(zap.WarnLevel))
+}
+
+func TestDynamicLevel(t *testing.T) {
+	dynamicLevel := zap.NewAtomicLevel()
+	dynamicLevel.SetLevel(zap.ErrorLevel)
+
+	var core, err = gelf.NewCore(
+		gelf.DynamicLevel(dynamicLevel),
+	)
+
+	assert.Nil(t, err, "Unexpected error")
+	assert.Implements(t, (*zapcore.Core)(nil), core, "Expect zapcore.Core")
+	assert.True(t, core.Enabled(zap.ErrorLevel))
+	assert.False(t, core.Enabled(zap.WarnLevel))
+
+	dynamicLevel.SetLevel(zap.WarnLevel)
+
+	assert.True(t, core.Enabled(zap.ErrorLevel))
+	assert.True(t, core.Enabled(zap.WarnLevel))
 }
 
 func TestChunkSize(t *testing.T) {


### PR DESCRIPTION
If the code uses multiple zep loggers and wants to synchronize ways to control them, AtomicLevel could be used.